### PR TITLE
Add "-pthread" argument to fix gtest link errors

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,6 +3,10 @@ include_directories(${GTEST_INCLUDE_DIR})
 include_directories(${CMAKE_SOURCE_DIR}/tests)
 add_definitions("-DDATADIR=\"${LIBKML_DATA_DIR}\"")
 
+if(NOT MSVC)
+  add_link_options(-pthread)
+endif()
+
 add_subdirectory(kml)
 if(WITH_SWIG)
   add_subdirectory(swig)


### PR DESCRIPTION
Building tests with the current version of gtest (a.k.a. googletest) results in pthread-related link errors, most easily resolved by adding the "-pthread" linker argument.